### PR TITLE
fix: Update zurg's plex_update.sh post hook script

### DIFF
--- a/charts/other/myprecious/templates/configmaps/configmap-zurg-config.yaml
+++ b/charts/other/myprecious/templates/configmaps/configmap-zurg-config.yaml
@@ -100,19 +100,21 @@ data:
         modified_arg="$zurg_mount/$arg"
         echo "Detected update on: $arg"
         echo "Absolute path: $modified_arg"
+        # remove any backslashes from the path
+        abs_path=$(echo "$modified_arg" | sed 's/\\//g')
 
         ##### START Added by ElfHosted for auto DMM symlinking ###
-        echo "Symlinking $modified_arg to /storage/symlinks/real-debrid-blackhole/$arg"
+        echo "Symlinking $abs_path to /storage/symlinks/real-debrid-blackhole/$arg"
 
         # Ensure blackhole exists
         mkdir -p /storage/symlinks/real-debrid-blackhole/movies
         mkdir -p /storage/symlinks/real-debrid-blackhole/shows
 
         # Copy to the RD blackhole, preserving the directory structure
-        cp -rs "$modified_arg/"* "/storage/symlinks/real-debrid-blackhole/$(echo $arg | cut -f1 -d/)/"
+        cp -rsv "$abs_path"/ "/storage/symlinks/real-debrid-blackhole/$(echo $arg | cut -f1 -d/)/"
         ##### END Added by ElfHosted for auto DMM symlinking ###
 
-        encoded_arg=$(echo -n "$modified_arg" | python3 -c "import sys, urllib.parse as ul; print (ul.quote_plus(sys.stdin.read()))")
+        encoded_arg=$(echo -n "$abs_path" | python3 -c "import sys, urllib.parse as ul; print (ul.quote_plus(sys.stdin.read()))")
 
         if [ -z "$encoded_arg" ]; then
             echo "Error: Encoded argument is empty. Check the input or encoding process."


### PR DESCRIPTION
The `plex_update.sh` script seems to be having issues populating the `/storage/symlinks/real-debrid-blackhole/` directory, and the `cp` command was unable to find directories to create symbolic links from in certain circumstances:

```
cp: cannot stat '/storage/realdebrid-zurg/shows/Aqua Teen Hunger Force (2000) Season 1-11 S01-11 (Mixed x265 HEVC 10bit Mixed r00t)/*': No such file or directory
```

In addition, I noticed a broken `*` (asterisk) symlink file was being created in the `/storage/realdebrid-zurg/shows/` folder.

----

With the changes in this pull request, we get output like this:

```
Detected update on: __all__/South\ Park\ -\ Seasons\ 1\ to\ 25
Absolute path: /storage/realdebrid-zurg/__all__/South\ Park\ -\ Seasons\ 1\ to\ 25
Symlinking /storage/realdebrid-zurg/__all__/South Park - Seasons 1 to 25 to /storage/symlinks/real-debrid-blackhole/__all__/South\ Park\ -\ Seasons\ 1\ to\ 25
Encoded argument: %2Fstorage%2Frealdebrid-zurg%2F__all__%2FSouth+Park+-+Seasons+1+to+25
```

In addition, I noticed `/symlinks/real-debrid-blackhole/__all__/` was finally getting created and populated for me.

-----

This works for me when using debridmediamanager directly, while bypassing overseerr + riven. 

Adding media via overseerr + riven still continues to work fine.